### PR TITLE
feat: Apply comprehensive styling updates to homepage

### DIFF
--- a/index.html
+++ b/index.html
@@ -5,6 +5,10 @@
     <link rel="icon" type="image/x-icon" href="/favicon.ico" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Gooma United - Belgian Soccer Team</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Montserrat:ital,wght@0,100..900;1,100..900&display=swap" rel="stylesheet">
+    <link href="https://fonts.googleapis.com/css2?family=Gochi+Hand&display=swap" rel="stylesheet">
   </head>
   <body>
     <div id="root"></div>

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -16,7 +16,7 @@ function App() {
   return (
     <AuthProvider>
       <Router>
-        <div className="min-h-screen bg-gray-50 flex flex-col">
+        <div className="min-h-screen bg-gray-50 flex flex-col font-sans">
           <Navigation />
           <main className="flex-grow">
             <Routes>

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -12,7 +12,7 @@
   "home": {
     "hero": {
       "title": "GOOMA UNITED",
-      "subtitle": "Passion, Excellence, Victory. Join us on our journey to greatness in Belgian football.",
+      "subtitle": "When Gooma is United, they will never be divided",
       "viewMatches": "View Matches",
       "meetTeam": "Meet the Team"
     },

--- a/src/locales/nl.json
+++ b/src/locales/nl.json
@@ -12,7 +12,7 @@
   "home": {
     "hero": {
       "title": "GOOMA UNITED",
-      "subtitle": "Passie, Uitmuntendheid, Overwinning. Sluit je aan bij onze reis naar grootsheid in de Belgische voetbal.",
+      "subtitle": "When Gooma is United, they will never be divided",
       "viewMatches": "Bekijk Wedstrijden",
       "meetTeam": "Ontmoet het Team"
     },

--- a/src/pages/Home.jsx
+++ b/src/pages/Home.jsx
@@ -73,7 +73,7 @@ const Home = () => {
               GOOMA
               <span className="block text-red-400" style={{textShadow: '3px 3px 6px rgba(0,0,0,0.9)'}}>UNITED</span>
             </h1>
-            <p className="text-xl md:text-2xl mb-8 text-gray-100 max-w-2xl mx-auto" style={{textShadow: '2px 2px 4px rgba(0,0,0,0.8)'}}>
+            <p className="text-xl md:text-2xl mb-8 text-gray-100 max-w-2xl mx-auto font-gochi" style={{textShadow: '2px 2px 4px rgba(0,0,0,0.8)'}}>
               {t('home.hero.subtitle')}
             </p>
             <div className="flex flex-col sm:flex-row gap-4 justify-center">
@@ -116,24 +116,24 @@ const Home = () => {
         <div className="relative max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
           <div className="text-center mb-12">
             <h2 className="text-3xl md:text-4xl font-bold mb-4">Club Statistics</h2>
-            <p className="text-red-100 text-lg">Our journey and achievements over the years</p>
+            <p className="text-2xl font-gochi">When Gooma is United, they will never be divided</p>
           </div>
           <div className="grid grid-cols-2 md:grid-cols-4 gap-8 text-center">
             <div className="bg-white bg-opacity-10 rounded-xl p-6 backdrop-blur-sm transform hover:scale-105 transition-all duration-300 hover:bg-opacity-20">
-              <div className="text-4xl md:text-5xl font-bold mb-3 text-white">15</div>
-              <div className="text-red-100 font-medium">{t('home.stats.yearsExcellence')}</div>
+              <div className="text-4xl md:text-5xl font-bold mb-3 text-black">15</div>
+              <div className="text-red-800 font-medium">{t('home.stats.yearsExcellence')}</div>
             </div>
             <div className="bg-white bg-opacity-10 rounded-xl p-6 backdrop-blur-sm transform hover:scale-105 transition-all duration-300 hover:bg-opacity-20">
-              <div className="text-4xl md:text-5xl font-bold mb-3 text-white">3</div>
-              <div className="text-red-100 font-medium">{t('home.stats.leagueTitles')}</div>
+              <div className="text-4xl md:text-5xl font-bold mb-3 text-black">3</div>
+              <div className="text-red-800 font-medium">{t('home.stats.leagueTitles')}</div>
             </div>
             <div className="bg-white bg-opacity-10 rounded-xl p-6 backdrop-blur-sm transform hover:scale-105 transition-all duration-300 hover:bg-opacity-20">
-              <div className="text-4xl md:text-5xl font-bold mb-3 text-white">25</div>
-              <div className="text-red-100 font-medium">{t('home.stats.squadPlayers')}</div>
+              <div className="text-4xl md:text-5xl font-bold mb-3 text-black">25</div>
+              <div className="text-red-800 font-medium">{t('home.stats.squadPlayers')}</div>
             </div>
             <div className="bg-white bg-opacity-10 rounded-xl p-6 backdrop-blur-sm transform hover:scale-105 transition-all duration-300 hover:bg-opacity-20">
-              <div className="text-4xl md:text-5xl font-bold mb-3 text-white">10K</div>
-              <div className="text-red-100 font-medium">{t('home.stats.loyalFans')}</div>
+              <div className="text-4xl md:text-5xl font-bold mb-3 text-black">10K</div>
+              <div className="text-red-800 font-medium">{t('home.stats.loyalFans')}</div>
             </div>
           </div>
         </div>

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -5,7 +5,12 @@ export default {
     "./src/**/*.{js,ts,jsx,tsx}",
   ],
   theme: {
-    extend: {},
+    extend: {
+      fontFamily: {
+        sans: ['Montserrat', 'sans-serif'],
+        gochi: ['"Gochi Hand"', 'cursive'],
+      },
+    },
   },
   plugins: [],
 }


### PR DESCRIPTION
This commit introduces a series of visual and content updates to the homepage based on user feedback.

Key changes include:
- The default font for the entire site has been set to "Montserrat". This is enforced by adding the `font-sans` class to the root App component to prevent style conflicts.
- The slogan "When Gooma is United, they will never be divided" is now used as the subtitle in both the hero and Club Statistics sections.
- The "Gochi Hand" font is applied to this slogan for a distinct, handwritten look.
- The text colors within the Club Statistics cards have been changed to black and dark red to improve visibility.
- All necessary fonts ("Montserrat" and "Gochi Hand") are imported from Google Fonts and configured in Tailwind CSS.