### PR TITLE
Fix CSS build issue related to custom fonts

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -115,6 +115,6 @@
     @apply border-border outline-ring/50;
   }
   body {
-    @apply bg-background text-foreground font-montserrat;
+    @apply bg-background text-foreground font-sans;
   }
 }

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -7,8 +7,8 @@ export default {
   theme: {
     extend: {
       fontFamily: {
-        'montserrat': ['"Montserrat"', 'sans-serif'],
-        'gochi': ['"Gochi Hand"', 'cursive'],
+        sans: ['"Montserrat"', 'sans-serif'],
+        gochi: ['"Gochi Hand"', 'cursive'],
       },
     },
   },


### PR DESCRIPTION
The project was failing to build due to an issue with how a custom font ('Montserrat') was being defined and used within Tailwind CSS v4. The build would fail with an error indicating that the 'font-montserrat' utility class was unknown.

This was resolved by modifying the `tailwind.config.js` to override the default `sans` font family with 'Montserrat'. The CSS was then updated to use the standard `font-sans` utility class. This is a more robust method for applying a primary custom font and resolves the build failure.

The changes ensure that the CSS is processed correctly, allowing the project to be built successfully.