### PR TITLE
feat: Implement 'League Spartan' as the primary font

### DIFF
--- a/index.html
+++ b/index.html
@@ -7,7 +7,7 @@
     <title>Gooma United - Belgian Soccer Team</title>
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-    <link href="https://fonts.googleapis.com/css2?family=Montserrat:wght@400;700&display=swap" rel="stylesheet">
+    <link href="https://fonts.googleapis.com/css2?family=League+Spartan:wght@400;700&display=swap" rel="stylesheet">
     <link href="https://fonts.googleapis.com/css2?family=Gochi+Hand&display=swap" rel="stylesheet">
   </head>
   <body>

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -7,7 +7,7 @@ export default {
   theme: {
     extend: {
       fontFamily: {
-        sans: ['"Montserrat"', 'sans-serif'],
+        sans: ['"League Spartan"', 'sans-serif'],
         gochi: ['"Gochi Hand"', 'cursive'],
       },
     },


### PR DESCRIPTION
This commit updates the application's typography to use 'League Spartan' as the primary font for all text, as requested.

The changes include:
- Updating `index.html` to import the 'League Spartan' font from Google Fonts and removing the previous 'Montserrat' font.
- Modifying `tailwind.config.js` to set 'League Spartan' as the default `sans` font family.

The project has been successfully built with these changes, ensuring the new font is correctly applied throughout the application.