### PR TITLE
Fix Netlify build failure caused by incorrect CSS imports.

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -10,9 +10,6 @@ import News from './pages/News.jsx';
 import History from './pages/History.jsx';
 import Admin from './pages/Admin.jsx';
 import PlayerProfile from './pages/PlayerProfile.jsx';
-import './App.css';
-import './global.css';
-import './slogan.css';
 
 function App() {
   return (

--- a/src/index.css
+++ b/src/index.css
@@ -1,12 +1,11 @@
 @import url('https://fonts.googleapis.com/css2?family=Gochi+Hand&display=swap');
+@import "tailwindcss";
+@import "tw-animate-css";
 
 /* Utility class for Gochi Hand font */
 .font-gochi {
   font-family: '"Gochi Hand"', cursive;
 }
-
-@import "tailwindcss";
-@import "tw-animate-css";
 
 /* Removed unsupported @custom-variant at-rule */
 

--- a/src/pages/Admin.jsx
+++ b/src/pages/Admin.jsx
@@ -36,10 +36,6 @@ import {
   updateTeam,
 } from '../services/database';
 
-import '../App.css';
-import '../global.css';
-import '../slogan.css';
-
 const Admin = () => {
   const { currentUser, logout } = useAuth();
   const [activeTab, setActiveTab] = useState('dashboard');


### PR DESCRIPTION
The Netlify deployment was failing due to a build error. The error was caused by components (`App.jsx`, `Admin.jsx`) trying to import CSS files (`App.css`, `global.css`) that were removed in a previous refactor. Additionally, the main CSS file (`index.css`) had an incorrect `@import` order.

This commit fixes the build by:
- Removing the invalid CSS import statements from `App.jsx` and `Admin.jsx`.
- Correcting the order of `@import` rules in `src/index.css` to comply with the CSS specification.

The local build now completes successfully.