### PR TITLE
Feat: Add match result management to admin panel

### DIFF
--- a/src/services/database.js
+++ b/src/services/database.js
@@ -29,6 +29,34 @@ export const addMatch = async (matchData) => {
   }
 };
 
+// One-time function to uniformise match data
+export const uniformiseMatchData = async () => {
+  try {
+    const matches = await getMatches();
+    const updatePromises = [];
+    matches.forEach(match => {
+      if (match.status === undefined || match.result === undefined) {
+        const matchRef = doc(db, 'matches', match.id);
+        updatePromises.push(updateDoc(matchRef, {
+          status: match.status || 'upcoming',
+          result: match.result || null
+        }));
+      }
+    });
+
+    if (updatePromises.length === 0) {
+      return { success: true, message: 'All matches are already uniform.' };
+    }
+
+    await Promise.all(updatePromises);
+    console.log(`${updatePromises.length} matches updated successfully.`);
+    return { success: true, message: `Uniformised ${updatePromises.length} matches.` };
+  } catch (error) {
+    console.error('Error uniformising match data:', error);
+    throw error;
+  }
+};
+
 // One-time function to update all teams with the tenueicon
 export const addTenueIconToAllTeams = async () => {
   try {


### PR DESCRIPTION
This commit introduces the ability for an administrator to add and edit match results, including the match status ('upcoming' or 'completed') and the final score.

The key changes are:
- The 'Add/Edit Match' form in `Admin.jsx` has been updated with a dropdown for status and number inputs for the home and away scores.
- The state management and data saving logic in `Admin.jsx` have been updated to handle the new fields, saving the score as a nested `result` object in Firestore.
- A new data migration function, `uniformiseMatchData`, has been added to `database.js` to ensure all existing match documents have the new `status` and `result` fields, maintaining data consistency.
- A temporary button has been added to the admin dashboard to trigger this one-time data migration.